### PR TITLE
Fix documentation typos and chaincode variable typo

### DIFF
--- a/01_history/bitcoin.md
+++ b/01_history/bitcoin.md
@@ -14,7 +14,7 @@
 
 ![Adam Back](_images/Adam_Back.png)
 
-1997 年，[Adam Back](https://en.wikipedia.org/wiki/Adam_Back) 提出了 [HashCash](http://en.wikipedia.org/wiki/Hashcash)，来解决邮件系统和博客网站中“拒绝服务攻击（Deny of Service，DoS）”攻击问题。Hashcash 首次应用工作量证明（Proof of Work，PoW）机制来获取额度，该机制后来被比特币所采用。类似思想最早曾在 1993 年的论文《Pricing via processing or combatting junk mail》中提出。
+1997 年，[Adam Back](https://en.wikipedia.org/wiki/Adam_Back) 提出了 [HashCash](http://en.wikipedia.org/wiki/Hashcash)，来解决邮件系统和博客网站中“拒绝服务攻击（Deny of Service，DoS）”攻击问题。Hashcash 首次应用工作量证明（Proof of Work，PoW）机制来获取额度，该机制后来被比特币所采用。类似思想最早曾在 1993 年的论文《Pricing via processing or combating junk mail》中提出。
 
 ![Wei Dai](_images/Wei_Dai.png)
 

--- a/09_fabric_deploy/install_docker.md
+++ b/09_fabric_deploy/install_docker.md
@@ -144,7 +144,7 @@ $ docker tag yeasy/hyperledger-fabric-peer:$PROJECT_VERSION hyperledger/fabric-p
 
 ### 镜像 Dockerfile
 
-读者也可自行通过编写 Dockefile 的方式来生成相关镜像。
+读者也可自行通过编写 Dockerfile 的方式来生成相关镜像。
 
 Dockerfile 中指令跟本地编译过程十分类似，这里给出笔者编写的 fabric-base 镜像、fabric-orderer 镜像和 fabric-peer 镜像等关键镜像的 Dockerfile，供读者参考使用。
 

--- a/11_app_dev/chaincode_example05.go
+++ b/11_app_dev/chaincode_example05.go
@@ -7,17 +7,17 @@
 package main
 
 import (
-	"errors"
-	"fmt"
-	"strconv"
 	"crypto/md5"
 	"crypto/rand"
-	"encoding/json"
 	"encoding/base64"
 	"encoding/hex"
-	"io"
-	"time"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"github.com/hyperledger/fabric/core/chaincode/shim"
+	"io"
+	"strconv"
+	"time"
 )
 
 type SimpleChaincode struct {
@@ -196,8 +196,8 @@ func buyByAddress(stub shim.ChaincodeStubInterface, args []string) ([]byte, erro
 		return nil, errors.New("Verify sign data failed!")
 	}
 
-	buyValue, erro := strconv.Atoi(args[3])
-	if erro != nil {
+	buyValue, err := strconv.Atoi(args[3])
+	if err != nil {
 		return nil, errors.New("want integer number")
 	}
 	if homeSeller.Energy < buyValue && homeBuyer.Money < buyValue {
@@ -370,7 +370,7 @@ func getTransactions(stub shim.ChaincodeStubInterface) ([]Transaction, error) {
 	return nil, nil
 }
 
-func writeHome(stub shim.ChaincodeStubInterface, home Home) (error) {
+func writeHome(stub shim.ChaincodeStubInterface, home Home) error {
 	homeBytes, err := json.Marshal(&home)
 	if err != nil {
 		return errors.New("Marshalling Error" + err.Error())
@@ -382,7 +382,7 @@ func writeHome(stub shim.ChaincodeStubInterface, home Home) (error) {
 	return nil
 }
 
-func writeTransaction(stub shim.ChaincodeStubInterface, transaction Transaction) (error) {
+func writeTransaction(stub shim.ChaincodeStubInterface, transaction Transaction) error {
 	txBytes, err := json.Marshal(&transaction)
 	if err != nil {
 		return errors.New("Marshalling Error" + err.Error())

--- a/11_app_dev/chaincode_example06.go
+++ b/11_app_dev/chaincode_example06.go
@@ -182,7 +182,7 @@ func (t *SimpleChaincode) createUser(stub *shim.ChaincodeStub, args []string) ([
 		return nil,errors.New("Want integer number")
 	}
 
-	user = User{Name:args[0],Loction:args[1],Address:address,PriKey:priKey,PubKey:pubKey,Phone:args[2],Money:number}
+    user = User{Name:args[0],Location:args[1],Address:address,PriKey:priKey,PubKey:pubKey,Phone:args[2],Money:number}
 	err = writeUser(stub,user)
 	if err!= nil{
 		return nil,errors.New("write error")

--- a/13_fabric_design/protocol.md
+++ b/13_fabric_design/protocol.md
@@ -83,6 +83,6 @@ enum ConfidentialityLevel { PUBLIC = 0; CONFIDENTIAL = 1;}
 
 ### Consensus
 
-consensus 组件收到 `CHAIN_TRANSACTION` 类消息后，将其转换为 `CONENSUS` 消息，然后向所有的 VP 节点广播。
+consensus 组件收到 `CHAIN_TRANSACTION` 类消息后，将其转换为 `CONSENSUS` 消息，然后向所有的 VP 节点广播。
 
 收到 `CONSENSUS` 消息的节点会按照预定的 consensus 算法进行处理。


### PR DESCRIPTION
## Summary
- correct 'combatting' to 'combating' in bitcoin history chapter
- fix Dockerfile typo in docker install guide
- rename `erro` variable and correct 'Location' field name
- fix consensus typo in fabric design protocol

## Testing
- `codespell | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_687723aba1e883289d38f769d561b75b